### PR TITLE
Build update improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-dev/ckeditor_sdk
+build/*
 dev/builder/node_modules
 template/theme/css
 .idea

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ setup working documentation dev environment.
 
 1. Initialize and update Git submodules:
 
-        git submodule update --init --recursive
+        git update
 
 1. Call Grunt `setup` task to setup the CKEditor SDK builder:
 
@@ -52,6 +52,16 @@ setup working documentation dev environment.
         grunt setup
 
     Initializes the SDK builder.
+
+1. #### update
+
+        grunt update [OPTIONS]
+
+   ##### OPTIONS:
+
+       --sdk-submodule-version=VERSION
+
+    Specifies which branch of ckeditor-dev to checkout before update(major, master). Defaults to master.
 
 1. #### build
 

--- a/dev/builder/app.js
+++ b/dev/builder/app.js
@@ -29,7 +29,7 @@ var fs = require( 'fs' ),
     Sample = require( './lib/Sample' ),
 
     SAMPLES_PATH = '../../samples',
-    RELEASE_PATH = '../ckeditor_sdk',
+    RELEASE_PATH,
     BASE_PATH = path.resolve('../..'),
     // Will be resolved later based on the --dev option.
     CKEDITOR_VERSION,
@@ -388,7 +388,7 @@ function determineCKEditorVersion( dev ) {
 }
 
 function getZipFilename() {
-    return 'ckeditor_' + CKEDITOR_VERSION +  '_sdk.zip';
+    return opts.version + '.zip';
 }
 
 function zipBuild() {
@@ -513,6 +513,9 @@ function packbuild() {
 }
 
 function build( opts ) {
+
+    RELEASE_PATH = BASE_PATH + '/build/' + opts.version;
+
     console.log( 'Building', opts.version, 'version of CKEditor SDK.' );
     console.log( 'Removing old release directory', path.resolve( RELEASE_PATH ) );
 

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -6,10 +6,12 @@
 'use strict';
 
 module.exports = function( grunt ) {
-	var BUILDER_DIR = 'dev/builder';
+	var BUILDER_DIR = 'dev/builder',
+		CKEDITOR_VERSION = '4.0.0';
 
 	grunt.loadNpmTasks( 'grunt-shell' );
 	grunt.loadNpmTasks( 'grunt-contrib-compass' );
+	grunt.loadNpmTasks( 'grunt-text-replace' );
 
 	grunt.registerTask( 'default', 'build' );
 
@@ -52,6 +54,22 @@ module.exports = function( grunt ) {
 					'cd ' + BUILDER_DIR,
 					'./app.js' + ' validatelinks'
 				].join( '&&' )
+			},
+
+			'sdk-update': {
+				command: [
+					'cd vendor/ckeditor-presets',
+					'git checkout ' + ( grunt.option( 'sdk-submodule-version' ) || 'master' ),
+					'git describe --tags HEAD',
+					'cd ../..',
+					'git submodule update --init --recursive'
+				].join( '&&' ),
+				options: {
+					callback: function ( err, stdout, stderr, cb ) {
+						CKEDITOR_VERSION =  stdout.match( /\d\.\d\.\d/ )[0] || CKEDITOR_VERSION;
+						cb();
+					}
+				}
 			}
 		},
 
@@ -87,8 +105,26 @@ module.exports = function( grunt ) {
 					outputStyle: 'expanded'
 				}
 			}
+		},
+
+		replace: {
+			simplesample: {
+				src: [ 'samples/assets/simplesample.js' ],
+				dest: 'samples/assets/',
+				replacements: [ {
+					from: /cdn\.ckeditor\.com\/\d\.\d\.\d\/standard\-all\//,
+					to: function() {
+						return 'cdn.ckeditor.com/' + CKEDITOR_VERSION + '/standard-all/';
+					}
+				} ]
+			}
 		}
 	} );
+
+	grunt.registerTask( 'update', [
+		'shell:sdk-update',
+		'replace:simplesample'
+	] );
 
 	grunt.registerTask( 'setup', [
 		'shell:builder-cleanup',

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
 	"dependencies": {
 		"grunt": "~0.4.5",
 		"grunt-shell": "~0.5.0",
-		"grunt-contrib-compass": "~1.0.1"
+		"grunt-contrib-compass": "~1.0.1",
+		"grunt-text-replace": "^0.4.0"
 	},
 	"scripts": {
 		"test": "node node_modules/benderjs/bin/bender run -b chrome"


### PR DESCRIPTION
This pull request contains a few adjustments to the build system, namely:

-Submodule update is now done through a grunt task that accepts a parameter which determines to which branch should ckeditor-dev be checked-out. Apart from that it modifies a line in samples/assets/simplesample.js so that it contains the URL to the current (as updated) version of CKEditor.

-Built files are placed in build/<version> (=online, offline) instead of dev/ckeditor. Similarly when using the --sdk-pack flag the zip file is placed in the path: build/<version>.zip.