### PR TITLE
Build update improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-dev/ckeditor_sdk
+build/*
 dev/builder/node_modules
 template/theme/css
 .idea

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ setup working documentation dev environment.
 
 1. Initialize and update Git submodules:
 
-        git submodule update --init --recursive
+        git update
 
 1. Call Grunt `setup` task to setup the CKEditor SDK builder:
 
@@ -52,6 +52,16 @@ setup working documentation dev environment.
         grunt setup
 
     Initializes the SDK builder.
+
+1. #### update
+
+        grunt update [OPTIONS]
+
+   ##### OPTIONS:
+
+       --sdk-submodule-version=VERSION
+
+    Specifies which branch of ckeditor-dev to checkout before update(major, master). Defaults to master.
 
 1. #### build
 

--- a/README.md
+++ b/README.md
@@ -31,13 +31,13 @@ setup working documentation dev environment.
 
         npm install
 
-1. Initialize and update Git submodules:
-
-        grunt update
-
-1. Call Grunt `setup` task to setup the CKEditor SDK builder:
+1. Setup the the builder, submodules, etc.:
 
         grunt setup
+
+1. (**Optional**) Update Git submodules (will commit submodule HEADs change):
+
+        grunt update
 
 1. Run Grunt `build` task to build the CKEditor SDK:
 
@@ -57,11 +57,13 @@ setup working documentation dev environment.
 
         grunt update [OPTIONS]
 
-   ##### OPTIONS:
+    Updates CKEditor presets and CKEditor docs submodules to the `--sdk-ckeditor-version` (defaults to `master`), commits this change and updates all submodules recursively.
+
+    ##### OPTIONS:
 
        --sdk-ckeditor-version=VERSION
 
-    Specifies which branch (or version - described by tag) of ckeditor-dev to checkout before update. Defaults to master.
+    Specifies which branch or tag to checkout the submodules. Defaults to `master`.
 
 1. #### build
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ setup working documentation dev environment.
 
 1. Initialize and update Git submodules:
 
-        git update
+        grunt update
 
 1. Call Grunt `setup` task to setup the CKEditor SDK builder:
 
@@ -59,9 +59,9 @@ setup working documentation dev environment.
 
    ##### OPTIONS:
 
-       --sdk-submodule-version=VERSION
+       --sdk-ckeditor-version=VERSION
 
-    Specifies which branch of ckeditor-dev to checkout before update(major, master). Defaults to master.
+    Specifies which branch (or version - described by tag) of ckeditor-dev to checkout before update. Defaults to master.
 
 1. #### build
 

--- a/dev/builder/app.js
+++ b/dev/builder/app.js
@@ -603,7 +603,7 @@ function buildDocumentation( dev ) {
         var args = [
             '--gruntfile', '../../docs/gruntfile.js',
             '--seo', false,
-            '--guides', '../dev/guides/guides.json',
+            '--guides', RELEASE_PATH + '/../guides/guides.json',
             '--path'
         ];
 
@@ -681,7 +681,7 @@ function fixGuidesLinks( urls ) {
             return url.match( /\.md$/ );
         } )
         .map( function( url ) {
-            url = path.resolve( '../guides/' + url );
+            url = path.resolve( RELEASE_PATH + '/../guides/' + url );
             var promise = whenFs.readFile( url, 'utf8' );
 
             return [ url, promise ];

--- a/dev/builder/app.js
+++ b/dev/builder/app.js
@@ -29,7 +29,7 @@ var fs = require( 'fs' ),
     Sample = require( './lib/Sample' ),
 
     SAMPLES_PATH = '../../samples',
-    RELEASE_PATH = '../ckeditor_sdk',
+    RELEASE_PATH,
     BASE_PATH = path.resolve('../..'),
     // Will be resolved later based on the --dev option.
     CKEDITOR_VERSION,
@@ -394,7 +394,7 @@ function determineCKEditorVersion( dev ) {
 }
 
 function getZipFilename() {
-    return 'ckeditor_' + CKEDITOR_VERSION +  '_sdk.zip';
+    return opts.version + '.zip';
 }
 
 function zipBuild() {
@@ -519,6 +519,9 @@ function packbuild() {
 }
 
 function build( opts ) {
+
+    RELEASE_PATH = BASE_PATH + '/build/' + opts.version;
+
     console.log( 'Building', opts.version, 'version of CKEditor SDK.' );
     console.log( 'Removing old release directory', path.resolve( RELEASE_PATH ) );
 

--- a/dev/builder/app.js
+++ b/dev/builder/app.js
@@ -259,7 +259,7 @@ function copyGuides() {
         } ).done( function() {
             resolve( urls );
         }, reject);
-    });
+    } );
 }
 
 function copyMathjaxFiles() {
@@ -578,7 +578,7 @@ function build( opts ) {
                     .then( buildDocumentation( opts.dev ) )
                     .then( curryExec( 'mv', [ '../../docs/build', RELEASE_PATH + '/docs' ] ) )
                     .then( fixdocs )
-                    .then( curryExec( 'rm', [ '-rf', '../guides' ] ) )
+                    .then( curryExec( 'rm', [ '-rf', RELEASE_PATH + '/../guides' ] ) )
                     .then( function() {
                         if ( opts.pack ) {
                             return packbuild();

--- a/dev/builder/app.js
+++ b/dev/builder/app.js
@@ -199,7 +199,22 @@ function copySamples() {
     }
 
     var options = {
-        filter: createNcpBlacklistFilter( blacklist )
+        filter: createNcpBlacklistFilter( blacklist ),
+        transform: function( read, write ) {
+            if ( read.path.match( /simplesample.js$/ )) {
+                var content = '';
+
+                read.on( 'data', function( chunk ) {
+                    content += chunk;
+                });
+
+                read.on( 'end', function() {
+                    write.end( content.replace( '<CKEditorVersion>', CKEDITOR_VERSION) );
+                });
+            } else {
+                read.pipe( write );
+            }
+        }
     };
 
     return call( ncp, '../../samples', path.join( RELEASE_PATH, 'samples' ), options );

--- a/dev/builder/app.js
+++ b/dev/builder/app.js
@@ -206,11 +206,11 @@ function copySamples() {
 
                 read.on( 'data', function( chunk ) {
                     content += chunk;
-                });
+                } );
 
                 read.on( 'end', function() {
-                    write.end( content.replace( '<CKEditorVersion>', CKEDITOR_VERSION) );
-                });
+                    write.end( content.replace( /<CKEditorVersion>/g, CKEDITOR_VERSION ) );
+                } );
             } else {
                 read.pipe( write );
             }
@@ -409,7 +409,7 @@ function determineCKEditorVersion( dev ) {
 }
 
 function getZipFilename() {
-    return opts.version + '.zip';
+    return 'ckeditor-sdk-' + opts.version + '.zip';
 }
 
 function zipBuild() {
@@ -534,7 +534,6 @@ function packbuild() {
 }
 
 function build( opts ) {
-
     RELEASE_PATH = BASE_PATH + '/build/' + opts.version;
 
     console.log( 'Building', opts.version, 'version of CKEditor SDK.' );

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -42,6 +42,7 @@ module.exports = function( grunt ) {
 
 			'sdk-build': {
 				command: [
+					'mkdir -p build',
 					'cd ' + BUILDER_DIR,
 					[
 						'node ./app.js',
@@ -68,20 +69,6 @@ module.exports = function( grunt ) {
 					'cd ../..',
 					'git submodule update --init --recursive'
 				].join( '&&' )
-			},
-
-			'sdk-get-version': {
-				command: [
-					'cd vendor/ckeditor-presets',
-					'git describe --tags HEAD',
-					'cd ../..'
-				].join( '&&' ),
-				options: {
-					callback: function( err, stdout, stderr, cb ) {
-						CKEDITOR_VERSION =  stdout.match( /\d\.\d\.\d/ )[0] || CKEDITOR_VERSION;
-						cb();
-					}
-				}
 			}
 		},
 
@@ -144,9 +131,7 @@ module.exports = function( grunt ) {
 
 	grunt.registerTask( 'build', [
 		'compass:sdk-build-css',
-		'shell:sdk-build',
-		'shell:sdk-get-version',
-		'replace:simplesample'
+		'shell:sdk-build'
 	] );
 
 	grunt.registerTask( 'watch-css', [

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
 	"dependencies": {
 		"grunt": "~0.4.5",
 		"grunt-shell": "~0.5.0",
-		"grunt-contrib-compass": "~1.0.1"
+		"grunt-contrib-compass": "~1.0.1",
+		"grunt-text-replace": "^0.4.0"
 	},
 	"scripts": {
 		"test": "node node_modules/benderjs/bin/bender run -b chrome"

--- a/samples/assets/simplesample.js
+++ b/samples/assets/simplesample.js
@@ -199,7 +199,7 @@
 				}
 			}
 
-			headResources.unshift( '<script src="http://cdn.ckeditor.com/4.5.2/standard-all/ckeditor.js"></script>' );
+			headResources.unshift( '<script src="http://cdn.ckeditor.com/<CKEditorVersion>/standard-all/ckeditor.js"></script>' );
 			headResources = headResources.join( '' );
 
 			function getTemplatePre( headResources, title ) {


### PR DESCRIPTION
This pull request contains a few adjustments to the build system, namely:

-Submodule update is now done through a grunt task that accepts a parameter which determines to which branch should ckeditor-dev be checked-out. Apart from that it modifies a line in samples/assets/simplesample.js so that it contains the URL to the current (as updated) version of CKEditor.

-Built files are placed in build/ (=online, offline) instead of dev/ckeditor. Similarly when using the --sdk-pack flag the zip file is placed in the path: build/.zip.