### PR TITLE
Change anchors that open code samples to buttons.

### DIFF
--- a/samples/assets/simplesample.js
+++ b/samples/assets/simplesample.js
@@ -154,7 +154,7 @@
 			e.returnValue = false;
 			e.preventDefault && e.preventDefault();
 
-			if ( clicked instanceof HTMLAnchorElement ) {
+			if ( clicked instanceof HTMLButtonElement ) {
 				relLi = clicked.parentNode;
 			} else {
 				return false;
@@ -498,10 +498,10 @@
 	}
 
 	function prepareSamplesList( examples ) {
-		var template = '<div><h2>Get Sample Source Code</h2>' + '<ul>';
+		var template = '<div><h2>Get Sample Source Code</h2>' + '<ul class="code-samples">';
 
 		for ( var id in examples ) {
-			template += '<li data-sample="' + id + '"><a href="' + id + '">' + simpleSample.metaNames[ id - 1 ] + '</a></li>';
+			template += '<li data-sample="' + id + '"><button>' + simpleSample.metaNames[ id - 1 ] + '</button></li>';
 		}
 		template += '</ul></div>';
 

--- a/template/theme/sass/partials/_contents.scss
+++ b/template/theme/sass/partials/_contents.scss
@@ -81,6 +81,14 @@ It is forbidden to copy and distribute this file in its original or modified for
 		&.spacious li {
 			margin: $std-standard-vgap/2;
 		}
+
+		&.code-samples {
+			list-style: none;
+
+			li {
+				margin-bottom: 0.5em;
+			}
+		}
 	}
 
 	pre, code, kbd


### PR DESCRIPTION
#147. I've seen buttons in other parts of the guide, so I guess it's only sensible to turn these anchors into button as well.