### PR TITLE
npm install docs on setup.

### DIFF
--- a/gruntfile.js
+++ b/gruntfile.js
@@ -22,6 +22,9 @@ module.exports = function( grunt ) {
 
 			'builder-setup': {
 				command: [
+					'cd docs',
+					'npm install',
+					'cd ..',
 					'cd ' + BUILDER_DIR,
 					'npm install'
 				].join( '&&' )


### PR DESCRIPTION
#157 

The build script assumed that some modules in the `docs` directory were installed and crashed as it discovered that it wasn't the case.