### PR TITLE
Make samples browsable in dev mode

### DIFF
--- a/dev/builder/app.js
+++ b/dev/builder/app.js
@@ -321,9 +321,11 @@ function prepareSamplesFilesSync() {
         sample.activateSamplesButton();
         if ( opts.version === 'offline' ) {
             sample.preventSearchEngineRobots();
+            sample.fixExternalPaths();
             sample.fixLinks();
             sample.fixFonts();
         } else {
+            sample.fixExternalPaths();
             sample.fixCKEDITORVendorLinks( CKEDITOR_VERSION );
         }
 

--- a/dev/builder/app.js
+++ b/dev/builder/app.js
@@ -201,7 +201,7 @@ function copySamples() {
     var options = {
         filter: createNcpBlacklistFilter( blacklist ),
         transform: function( read, write ) {
-            if ( read.path.match( /simplesample.js$/ )) {
+            if ( read.path.match( /samples\/assets\/simplesample\.js/ ) ) {
                 var content = '';
 
                 read.on( 'data', function( chunk ) {
@@ -209,7 +209,10 @@ function copySamples() {
                 } );
 
                 read.on( 'end', function() {
-                    write.end( content.replace( /<CKEditorVersion>/g, CKEDITOR_VERSION ) );
+                    content = content
+                        .replace( /\.\.\/template\/theme/g, '../theme' )
+                        .replace( /<CKEditorVersion>/g, CKEDITOR_VERSION );
+                    write.end( content );
                 } );
             } else {
                 read.pipe( write );

--- a/dev/builder/lib/Sample.js
+++ b/dev/builder/lib/Sample.js
@@ -117,16 +117,13 @@ Sample.prototype = {
     },
 
     fixExternalPaths: function() {
-        var that = this;
-        this.$( 'head link[href^="../template/theme"]' ).each( function ( index, element ) {
-            that.$( element ).attr( 'href', element.attribs[ 'href' ].replace( '../template/theme', '../theme' ) );
-        } );
-
         // This is bad, but there's no real alternative to this given,
         // that the path that needs to be modified may appear within a script.
         var html = this.$( 'html' ).html();
         if ( html ) {
-            this.$( 'html' ).html( html.replace( /\.\.\/\.\.\/ckeditor\-dev/g, '../vendor/ckeditor' ) );
+            this.$( 'html' ).html( html
+                .replace( /\.\.\/\.\.\/ckeditor\-dev/g, '../vendor/ckeditor' )
+                .replace( /\.\.\/template\/theme/g, '../theme' ) );
         }
     },
 

--- a/dev/builder/lib/Sample.js
+++ b/dev/builder/lib/Sample.js
@@ -116,6 +116,20 @@ Sample.prototype = {
         } );
     },
 
+    fixExternalPaths: function() {
+        var that = this;
+        this.$( 'head link[href^="../template/theme"]' ).each( function ( index, element ) {
+            that.$( element ).attr( 'href', element.attribs[ 'href' ].replace( '../template/theme', '../theme' ) );
+        } );
+
+        // This is bad, but there's no real alternative to this given,
+        // that the path that needs to be modified may appear within a script.
+        var html = this.$( 'html' ).html();
+        if ( html ) {
+            this.$( 'html' ).html( html.replace( /\.\.\/\.\.\/ckeditor\-dev/g, '../vendor/ckeditor' ) );
+        }
+    },
+
     fixCKEDITORVendorLinks: function( version ) {
         var that = this,
             cdnEditorLink = '//cdn.ckeditor.com/' + version + '/standard-all/';

--- a/samples/abbr.html
+++ b/samples/abbr.html
@@ -11,8 +11,8 @@ For licensing, see license.html or http://sdk.ckeditor.com/license.html.
 	<meta name="sdk-samples" content="Abbreviation plugin">
 	<title>Abbreviation Plugin</title>
 	<link href="http://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
-	<link href="../theme/css/sdk.css" rel="stylesheet">
-	<script src="../vendor/ckeditor/ckeditor.js"></script>
+	<link href="../template/theme/css/sdk.css" rel="stylesheet">
+	<script src="../../ckeditor-dev/ckeditor.js"></script>
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/sample.js"></script>
 	<script src="assets/contentloaded.js"></script>
@@ -21,7 +21,7 @@ For licensing, see license.html or http://sdk.ckeditor.com/license.html.
 	<!--[if lt IE 9]>
 	<script src="assets/html5shiv.min.js"></script>
 	<![endif]-->
-	<link rel="icon" href="../theme/img/favicon.ico">
+	<link rel="icon" href="../template/theme/img/favicon.ico">
 </head>
 <body>
 	<header class="sdk-header">

--- a/samples/accessibility.html
+++ b/samples/accessibility.html
@@ -11,8 +11,8 @@ For licensing, see license.html or http://sdk.ckeditor.com/license.html.
 	<meta name="sdk-samples" content="Accessibility support and keyboard shortcuts">
 	<title>Accessibility and Keyboard Shortcuts</title>
 	<link href="http://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
-	<link href="../theme/css/sdk.css" rel="stylesheet">
-	<script src="../vendor/ckeditor/ckeditor.js"></script>
+	<link href="../template/theme/css/sdk.css" rel="stylesheet">
+	<script src="../../ckeditor-dev/ckeditor.js"></script>
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/contentloaded.js"></script>
 	<script src="assets/simplesample.js"></script>
@@ -20,7 +20,7 @@ For licensing, see license.html or http://sdk.ckeditor.com/license.html.
 	<!--[if lt IE 9]>
 	<script src="assets/html5shiv.min.js"></script>
 	<![endif]-->
-	<link rel="icon" href="../theme/img/favicon.ico">
+	<link rel="icon" href="../template/theme/img/favicon.ico">
 </head>
 <body>
 	<header class="sdk-header">

--- a/samples/acf.html
+++ b/samples/acf.html
@@ -11,8 +11,8 @@ For licensing, see license.html or http://sdk.ckeditor.com/license.html.
 	<meta name="sdk-samples" content="Automatic ACF mode|Automatic ACF mode with extra allowed content|Disabling ACF">
 	<title>ACF &ndash; Automatic Mode</title>
 	<link href="http://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
-	<link href="../theme/css/sdk.css" rel="stylesheet">
-	<script src="../vendor/ckeditor/ckeditor.js"></script>
+	<link href="../template/theme/css/sdk.css" rel="stylesheet">
+	<script src="../../ckeditor-dev/ckeditor.js"></script>
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/contentloaded.js"></script>
 	<script src="assets/simplesample.js"></script>
@@ -20,7 +20,7 @@ For licensing, see license.html or http://sdk.ckeditor.com/license.html.
 	<!--[if lt IE 9]>
 	<script src="assets/html5shiv.min.js"></script>
 	<![endif]-->
-	<link rel="icon" href="../theme/img/favicon.ico">
+	<link rel="icon" href="../template/theme/img/favicon.ico">
 </head>
 <body>
 <header class="sdk-header">

--- a/samples/acfcustom.html
+++ b/samples/acfcustom.html
@@ -11,8 +11,8 @@ For licensing, see license.html or http://sdk.ckeditor.com/license.html.
 	<meta name="sdk-samples" content="Automatic ACF mode|Custom ACF mode">
 	<title>ACF &ndash; Custom Mode</title>
 	<link href="http://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
-	<link href="../theme/css/sdk.css" rel="stylesheet">
-	<script src="../vendor/ckeditor/ckeditor.js"></script>
+	<link href="../template/theme/css/sdk.css" rel="stylesheet">
+	<script src="../../ckeditor-dev/ckeditor.js"></script>
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/contentloaded.js"></script>
 	<script src="assets/simplesample.js"></script>
@@ -20,7 +20,7 @@ For licensing, see license.html or http://sdk.ckeditor.com/license.html.
 	<!--[if lt IE 9]>
 	<script src="assets/html5shiv.min.js"></script>
 	<![endif]-->
-	<link rel="icon" href="../theme/img/favicon.ico">
+	<link rel="icon" href="../template/theme/img/favicon.ico">
 </head>
 <body>
 	<header class="sdk-header">

--- a/samples/api.html
+++ b/samples/api.html
@@ -11,8 +11,8 @@ For licensing, see license.html or http://sdk.ckeditor.com/license.html.
 	<meta name="sdk-samples" content="Using CKEditor API">
 	<title>Using CKEditor API</title>
 	<link href="http://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
-	<link href="../theme/css/sdk.css" rel="stylesheet">
-	<script src="../vendor/ckeditor/ckeditor.js"></script>
+	<link href="../template/theme/css/sdk.css" rel="stylesheet">
+	<script src="../../ckeditor-dev/ckeditor.js"></script>
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/contentloaded.js"></script>
 	<script src="assets/simplesample.js"></script>
@@ -20,7 +20,7 @@ For licensing, see license.html or http://sdk.ckeditor.com/license.html.
 	<!--[if lt IE 9]>
 	<script src="assets/html5shiv.min.js"></script>
 	<![endif]-->
-	<link rel="icon" href="../theme/img/favicon.ico">
+	<link rel="icon" href="../template/theme/img/favicon.ico">
 </head>
 <body>
 	<header class="sdk-header">

--- a/samples/assets/simplesample.js
+++ b/samples/assets/simplesample.js
@@ -339,7 +339,7 @@
 						modalClass: 'source-code',
 						modalStyles: null,
 						closeStyles: null,
-						closeHtml: '<img src="../theme/img/close.png" alt="Close" />'
+						closeHtml: '<img src="../template/theme/img/close.png" alt="Close" />'
 					} ),
 					modalElem = new CKEDITOR.dom.element( modal.modalElem() ),
 					selectButton = modalElem.findOne( 'a.source-code-tab-select' ),

--- a/samples/autogrow.html
+++ b/samples/autogrow.html
@@ -11,8 +11,8 @@ For licensing, see license.html or http://sdk.ckeditor.com/license.html.
 	<meta name="sdk-samples" content="Automatic editor height adjustment to content">
 	<title>Editor Auto Grow</title>
 	<link href="http://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
-	<link href="../theme/css/sdk.css" rel="stylesheet">
-	<script src="../vendor/ckeditor/ckeditor.js"></script>
+	<link href="../template/theme/css/sdk.css" rel="stylesheet">
+	<script src="../../ckeditor-dev/ckeditor.js"></script>
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/contentloaded.js"></script>
 	<script src="assets/simplesample.js"></script>
@@ -20,7 +20,7 @@ For licensing, see license.html or http://sdk.ckeditor.com/license.html.
 	<!--[if lt IE 9]>
 	<script src="assets/html5shiv.min.js"></script>
 	<![endif]-->
-	<link rel="icon" href="../theme/img/favicon.ico">
+	<link rel="icon" href="../template/theme/img/favicon.ico">
 </head>
 <body>
 	<header class="sdk-header">

--- a/samples/basicstyles.html
+++ b/samples/basicstyles.html
@@ -11,8 +11,8 @@ For licensing, see license.html or http://sdk.ckeditor.com/license.html.
 	<meta name="sdk-samples" content="Default basic text styles|Custom basic text styles definition">
 	<title>Basic Text Styles</title>
 	<link href="http://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
-	<link href="../theme/css/sdk.css" rel="stylesheet">
-	<script src="../vendor/ckeditor/ckeditor.js"></script>
+	<link href="../template/theme/css/sdk.css" rel="stylesheet">
+	<script src="../../ckeditor-dev/ckeditor.js"></script>
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/sample.js"></script>
 	<script src="assets/contentloaded.js"></script>
@@ -21,7 +21,7 @@ For licensing, see license.html or http://sdk.ckeditor.com/license.html.
 	<!--[if lt IE 9]>
 	<script src="assets/html5shiv.min.js"></script>
 	<![endif]-->
-	<link rel="icon" href="../theme/img/favicon.ico">
+	<link rel="icon" href="../template/theme/img/favicon.ico">
 </head>
 <body>
 	<header class="sdk-header">

--- a/samples/bbcode.html
+++ b/samples/bbcode.html
@@ -11,16 +11,16 @@ For licensing, see license.html or http://sdk.ckeditor.com/license.html.
 	<meta name="sdk-samples" content="BBCode editing">
 	<title>BBCode Editing</title>
 	<link href="http://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
-	<link href="../theme/css/sdk.css" rel="stylesheet">
+	<link href="../template/theme/css/sdk.css" rel="stylesheet">
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/contentloaded.js"></script>
 	<script src="assets/simplesample.js"></script>
 	<script src="assets/beautify-html.js"></script>
-	<script src="../vendor/ckeditor/ckeditor.js"></script>
+	<script src="../../ckeditor-dev/ckeditor.js"></script>
 	<!--[if lt IE 9]>
 	<script src="assets/html5shiv.min.js"></script>
 	<![endif]-->
-	<link rel="icon" href="../theme/img/favicon.ico">
+	<link rel="icon" href="../template/theme/img/favicon.ico">
 </head>
 <body>
 	<header class="sdk-header">

--- a/samples/captionedimage.html
+++ b/samples/captionedimage.html
@@ -11,8 +11,8 @@ For licensing, see license.html or http://sdk.ckeditor.com/license.html.
 	<meta name="sdk-samples" content="Creating captioned images">
 	<title>Captioned Images</title>
 	<link href="http://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
-	<link href="../theme/css/sdk.css" rel="stylesheet">
-	<script src="../vendor/ckeditor/ckeditor.js"></script>
+	<link href="../template/theme/css/sdk.css" rel="stylesheet">
+	<script src="../../ckeditor-dev/ckeditor.js"></script>
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/contentloaded.js"></script>
 	<script src="assets/simplesample.js"></script>
@@ -21,7 +21,7 @@ For licensing, see license.html or http://sdk.ckeditor.com/license.html.
 	<!--[if lt IE 9]>
 	<script src="assets/html5shiv.min.js"></script>
 	<![endif]-->
-	<link rel="icon" href="../theme/img/favicon.ico">
+	<link rel="icon" href="../template/theme/img/favicon.ico">
 </head>
 <body>
 	<header class="sdk-header">

--- a/samples/classic.html
+++ b/samples/classic.html
@@ -11,8 +11,8 @@ For licensing, see license.html or http://sdk.ckeditor.com/license.html.
 	<meta name="sdk-samples" content="Classic editor with default styles|Classic editor with custom styles">
 	<title>Classic Editor</title>
 	<link href="http://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
-	<link href="../theme/css/sdk.css" rel="stylesheet">
-	<script src="../vendor/ckeditor/ckeditor.js"></script>
+	<link href="../template/theme/css/sdk.css" rel="stylesheet">
+	<script src="../../ckeditor-dev/ckeditor.js"></script>
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/contentloaded.js"></script>
 	<script src="assets/simplesample.js"></script>
@@ -20,7 +20,7 @@ For licensing, see license.html or http://sdk.ckeditor.com/license.html.
 	<!--[if lt IE 9]>
 	<script src="assets/html5shiv.min.js"></script>
 	<![endif]-->
-	<link rel="icon" href="../theme/img/favicon.ico">
+	<link rel="icon" href="../template/theme/img/favicon.ico">
 </head>
 <body>
 	<header class="sdk-header">
@@ -105,7 +105,7 @@ For licensing, see license.html or http://sdk.ckeditor.com/license.html.
 				CKEDITOR.replace( 'editor2', {
 					height: 260,
 					/* Default CKEditor styles are included as well to avoid copying default styles. */
-					contentsCss: [ '../vendor/ckeditor/contents.css', 'assets/css/classic.css' ]
+					contentsCss: [ '../../ckeditor-dev/contents.css', 'assets/css/classic.css' ]
 				} );
 			</script>
 

--- a/samples/codesnippet.html
+++ b/samples/codesnippet.html
@@ -11,8 +11,8 @@ For licensing, see license.html or http://sdk.ckeditor.com/license.html.
 	<meta name="sdk-samples" content="Using syntax highlighting">
 	<title>Code Snippets</title>
 	<link href="http://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
-	<link href="../theme/css/sdk.css" rel="stylesheet">
-	<script src="../vendor/ckeditor/ckeditor.js"></script>
+	<link href="../template/theme/css/sdk.css" rel="stylesheet">
+	<script src="../../ckeditor-dev/ckeditor.js"></script>
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/contentloaded.js"></script>
 	<script src="assets/simplesample.js"></script>
@@ -21,7 +21,7 @@ For licensing, see license.html or http://sdk.ckeditor.com/license.html.
 	<!--[if lt IE 9]>
 	<script src="assets/html5shiv.min.js"></script>
 	<![endif]-->
-	<link rel="icon" href="../theme/img/favicon.ico">
+	<link rel="icon" href="../template/theme/img/favicon.ico">
 </head>
 <body>
 	<header class="sdk-header">

--- a/samples/colorbutton.html
+++ b/samples/colorbutton.html
@@ -11,8 +11,8 @@ For licensing, see license.html or http://sdk.ckeditor.com/license.html.
 	<meta name="sdk-samples" content="Text and background color with Color Dialog|Custom text and background colors">
 	<title>Text and Background Color</title>
 	<link href="http://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
-	<link href="../theme/css/sdk.css" rel="stylesheet">
-	<script src="../vendor/ckeditor/ckeditor.js"></script>
+	<link href="../template/theme/css/sdk.css" rel="stylesheet">
+	<script src="../../ckeditor-dev/ckeditor.js"></script>
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/sample.js"></script>
 	<script src="assets/contentloaded.js"></script>
@@ -21,7 +21,7 @@ For licensing, see license.html or http://sdk.ckeditor.com/license.html.
 	<!--[if lt IE 9]>
 	<script src="assets/html5shiv.min.js"></script>
 	<![endif]-->
-	<link rel="icon" href="../theme/img/favicon.ico">
+	<link rel="icon" href="../template/theme/img/favicon.ico">
 </head>
 <body>
 	<header class="sdk-header">

--- a/samples/devtools.html
+++ b/samples/devtools.html
@@ -11,8 +11,8 @@ For licensing, see license.html or http://sdk.ckeditor.com/license.html.
 	<meta name="sdk-samples" content="Developer tools">
 	<title>Developer Tools</title>
 	<link href="http://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
-	<link href="../theme/css/sdk.css" rel="stylesheet">
-	<script src="../vendor/ckeditor/ckeditor.js"></script>
+	<link href="../template/theme/css/sdk.css" rel="stylesheet">
+	<script src="../../ckeditor-dev/ckeditor.js"></script>
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/contentloaded.js"></script>
 	<script src="assets/simplesample.js"></script>
@@ -20,7 +20,7 @@ For licensing, see license.html or http://sdk.ckeditor.com/license.html.
 	<!--[if lt IE 9]>
 	<script src="assets/html5shiv.min.js"></script>
 	<![endif]-->
-	<link rel="icon" href="../theme/img/favicon.ico">
+	<link rel="icon" href="../template/theme/img/favicon.ico">
 </head>
 <body>
 	<header class="sdk-header">

--- a/samples/draganddrop.html
+++ b/samples/draganddrop.html
@@ -11,8 +11,8 @@ For licensing, see license.html or http://sdk.ckeditor.com/license.html.
 	<meta name="sdk-samples" content="Drag and Drop Integration">
 	<title>Drag and Drop Integration</title>
 	<link href="http://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
-	<link href="../theme/css/sdk.css" rel="stylesheet">
-	<script src="../vendor/ckeditor/ckeditor.js"></script>
+	<link href="../template/theme/css/sdk.css" rel="stylesheet">
+	<script src="../../ckeditor-dev/ckeditor.js"></script>
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/sample.js"></script>
 	<script src="assets/contentloaded.js"></script>
@@ -21,7 +21,7 @@ For licensing, see license.html or http://sdk.ckeditor.com/license.html.
 	<!--[if lt IE 9]>
 	<script src="assets/html5shiv.min.js"></script>
 	<![endif]-->
-	<link rel="icon" href="../theme/img/favicon.ico">
+	<link rel="icon" href="../template/theme/img/favicon.ico">
 	<style data-sample="1">
 		.columns {
 			background: #fff;

--- a/samples/enterkey.html
+++ b/samples/enterkey.html
@@ -11,8 +11,8 @@ For licensing, see license.html or http://sdk.ckeditor.com/license.html.
 	<meta name="sdk-samples" content="Enter key configuration">
 	<title>Enter Key Configuration</title>
 	<link href="http://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
-	<link href="../theme/css/sdk.css" rel="stylesheet">
-	<script src="../vendor/ckeditor/ckeditor.js"></script>
+	<link href="../template/theme/css/sdk.css" rel="stylesheet">
+	<script src="../../ckeditor-dev/ckeditor.js"></script>
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/sample.js"></script>
 	<script src="assets/contentloaded.js"></script>
@@ -40,7 +40,7 @@ For licensing, see license.html or http://sdk.ckeditor.com/license.html.
 		window.onload = changeEnter;
 	</script>
 
-	<link rel="icon" href="../theme/img/favicon.ico">
+	<link rel="icon" href="../template/theme/img/favicon.ico">
 </head>
 <body>
 	<header class="sdk-header">

--- a/samples/fileupload.html
+++ b/samples/fileupload.html
@@ -11,8 +11,8 @@ For licensing, see license.html or http://sdk.ckeditor.com/license.html.
 	<meta name="sdk-samples" content="File Manager Integration|Uploading Dropped and Pasted Images">
 	<title>File Upload</title>
 	<link href="http://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
-	<link href="../theme/css/sdk.css" rel="stylesheet">
-	<script src="../vendor/ckeditor/ckeditor.js"></script>
+	<link href="../template/theme/css/sdk.css" rel="stylesheet">
+	<script src="../../ckeditor-dev/ckeditor.js"></script>
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/sample.js"></script>
 	<script src="assets/contentloaded.js"></script>
@@ -21,7 +21,7 @@ For licensing, see license.html or http://sdk.ckeditor.com/license.html.
 	<!--[if lt IE 9]>
 	<script src="assets/html5shiv.min.js"></script>
 	<![endif]-->
-	<link rel="icon" href="../theme/img/favicon.ico">
+	<link rel="icon" href="../template/theme/img/favicon.ico">
 </head>
 <body>
 	<header class="sdk-header">

--- a/samples/fixedui.html
+++ b/samples/fixedui.html
@@ -11,19 +11,19 @@ For licensing, see license.html or http://sdk.ckeditor.com/license.html.
 	<meta name="sdk-samples" content="Classic editor with fixed UI|Inline editor with fixed UI">
 	<title>Fixed User Interface</title>
 	<link href="http://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
-	<link href="../theme/css/sdk.css" rel="stylesheet">
-	<script src="../vendor/ckeditor/ckeditor.js"></script>
+	<link href="../template/theme/css/sdk.css" rel="stylesheet">
+	<script src="../../ckeditor-dev/ckeditor.js"></script>
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/contentloaded.js"></script>
 	<script src="assets/simplesample.js"></script>
 	<script src="assets/beautify-html.js"></script>
 	<script type="template" data-sample="2">
-		&lt;link href="../theme/css/sdk-inline.css" rel="stylesheet" /&gt;
+		&lt;link href="../template/theme/css/sdk-inline.css" rel="stylesheet" /&gt;
 	</script>
 	<!--[if lt IE 9]>
 	<script src="assets/html5shiv.min.js"></script>
 	<![endif]-->
-	<link rel="icon" href="../theme/img/favicon.ico">
+	<link rel="icon" href="../template/theme/img/favicon.ico">
 </head>
 <body>
 	<header class="sdk-header">

--- a/samples/floatingui.html
+++ b/samples/floatingui.html
@@ -11,11 +11,11 @@ For licensing, see license.html or http://sdk.ckeditor.com/license.html.
 	<meta name="sdk-samples" content="Inline editor with floating UI">
 	<title>Floating User Interface</title>
 	<link href="http://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
-	<link href="../theme/css/sdk.css" rel="stylesheet">
+	<link href="../template/theme/css/sdk.css" rel="stylesheet">
 	<script type="template" data-sample="1">
-		&lt;link href="../theme/css/sdk-inline.css" rel="stylesheet" /&gt;
+		&lt;link href="../template/theme/css/sdk-inline.css" rel="stylesheet" /&gt;
 	</script>
-	<script src="../vendor/ckeditor/ckeditor.js"></script>
+	<script src="../../ckeditor-dev/ckeditor.js"></script>
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/contentloaded.js"></script>
 	<script src="assets/simplesample.js"></script>
@@ -29,7 +29,7 @@ For licensing, see license.html or http://sdk.ckeditor.com/license.html.
 			padding: 10px;
 		}
 	</style>
-	<link rel="icon" href="../theme/img/favicon.ico">
+	<link rel="icon" href="../template/theme/img/favicon.ico">
 </head>
 <body>
 	<header class="sdk-header">

--- a/samples/format.html
+++ b/samples/format.html
@@ -11,8 +11,8 @@ For licensing, see license.html or http://sdk.ckeditor.com/license.html.
 	<meta name="sdk-samples" content="Default text formats|Custom text format definitions">
 	<title>Text Formats</title>
 	<link href="http://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
-	<link href="../theme/css/sdk.css" rel="stylesheet">
-	<script src="../vendor/ckeditor/ckeditor.js"></script>
+	<link href="../template/theme/css/sdk.css" rel="stylesheet">
+	<script src="../../ckeditor-dev/ckeditor.js"></script>
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/contentloaded.js"></script>
 	<script src="assets/simplesample.js"></script>
@@ -20,7 +20,7 @@ For licensing, see license.html or http://sdk.ckeditor.com/license.html.
 	<!--[if lt IE 9]>
 	<script src="assets/html5shiv.min.js"></script>
 	<![endif]-->
-	<link rel="icon" href="../theme/img/favicon.ico">
+	<link rel="icon" href="../template/theme/img/favicon.ico">
 </head>
 <body>
 	<header class="sdk-header">
@@ -157,7 +157,7 @@ for each item in sequence S
 					height: 280,
 					// Adding a custom stylesheet with some additional styles for text formats. 
 					// Default CKEditor styles are included as well to avoid copying default styles.
-					contentsCss: [ '../vendor/ckeditor/contents.css', 'assets/css/format.css' ],
+					contentsCss: [ '../../ckeditor-dev/contents.css', 'assets/css/format.css' ],
 					// List of text formats available for this editor instance.
 					format_tags: 'p;h1;h2;h3;pre;div',
 					// Custom Heading 1 and Formatted format definitions.

--- a/samples/fullpage.html
+++ b/samples/fullpage.html
@@ -11,8 +11,8 @@ For licensing, see license.html or http://sdk.ckeditor.com/license.html.
 	<meta name="sdk-samples" content="Full page editing with Document Properties plugin">
 	<title>Editing Complete HTML Pages</title>
 	<link href="http://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
-	<link href="../theme/css/sdk.css" rel="stylesheet">
-	<script src="../vendor/ckeditor/ckeditor.js"></script>
+	<link href="../template/theme/css/sdk.css" rel="stylesheet">
+	<script src="../../ckeditor-dev/ckeditor.js"></script>
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/contentloaded.js"></script>
 	<script src="assets/simplesample.js"></script>
@@ -21,7 +21,7 @@ For licensing, see license.html or http://sdk.ckeditor.com/license.html.
 	<!--[if lt IE 9]>
 	<script src="assets/html5shiv.min.js"></script>
 	<![endif]-->
-	<link rel="icon" href="../theme/img/favicon.ico">
+	<link rel="icon" href="../template/theme/img/favicon.ico">
 </head>
 <body>
 	<header class="sdk-header">

--- a/samples/htmlformatting.html
+++ b/samples/htmlformatting.html
@@ -11,8 +11,8 @@ For licensing, see license.html or http://sdk.ckeditor.com/license.html.
 	<meta name="sdk-samples" content="CKEditor with custom HTML formatting">
 	<title>HTML Output Formatting</title>
 	<link href="http://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
-	<link href="../theme/css/sdk.css" rel="stylesheet">
-	<script src="../vendor/ckeditor/ckeditor.js"></script>
+	<link href="../template/theme/css/sdk.css" rel="stylesheet">
+	<script src="../../ckeditor-dev/ckeditor.js"></script>
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/contentloaded.js"></script>
 	<script src="assets/simplesample.js"></script>
@@ -20,7 +20,7 @@ For licensing, see license.html or http://sdk.ckeditor.com/license.html.
 	<!--[if lt IE 9]>
 	<script src="assets/html5shiv.min.js"></script>
 	<![endif]-->
-	<link rel="icon" href="../theme/img/favicon.ico">
+	<link rel="icon" href="../template/theme/img/favicon.ico">
 </head>
 <body>
 	<header class="sdk-header">

--- a/samples/inline.html
+++ b/samples/inline.html
@@ -11,14 +11,14 @@ For licensing, see license.html or http://sdk.ckeditor.com/license.html.
 	<meta name="sdk-samples" content="Inline editing enabled by code|Massive inline editing">
 	<title>Inline Editor</title>
 	<link href="http://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
-	<link href="../theme/css/sdk.css" rel="stylesheet">
-	<script src="../vendor/ckeditor/ckeditor.js"></script>
+	<link href="../template/theme/css/sdk.css" rel="stylesheet">
+	<script src="../../ckeditor-dev/ckeditor.js"></script>
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/contentloaded.js"></script>
 	<script src="assets/simplesample.js"></script>
 	<script src="assets/beautify-html.js"></script>
 	<script type="template" data-sample="1,2">
-		&lt;link href="../theme/css/sdk-inline.css" rel="stylesheet" /&gt;
+		&lt;link href="../template/theme/css/sdk-inline.css" rel="stylesheet" /&gt;
 	</script>
 	<!--[if lt IE 9]>
 	<script src="assets/html5shiv.min.js"></script>
@@ -132,7 +132,7 @@ For licensing, see license.html or http://sdk.ckeditor.com/license.html.
 		}
 
 	</style>
-	<link rel="icon" href="../theme/img/favicon.ico">
+	<link rel="icon" href="../template/theme/img/favicon.ico">
 </head>
 <body>
 <header class="sdk-header">

--- a/samples/language.html
+++ b/samples/language.html
@@ -11,8 +11,8 @@ For licensing, see license.html or http://sdk.ckeditor.com/license.html.
 	<meta name="sdk-samples" content="Setting text direction|Setting text part language">
 	<title>Multilingual Content</title>
 	<link href="http://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
-	<link href="../theme/css/sdk.css" rel="stylesheet">
-	<script src="../vendor/ckeditor/ckeditor.js"></script>
+	<link href="../template/theme/css/sdk.css" rel="stylesheet">
+	<script src="../../ckeditor-dev/ckeditor.js"></script>
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/sample.js"></script>
 	<script src="assets/contentloaded.js"></script>
@@ -21,7 +21,7 @@ For licensing, see license.html or http://sdk.ckeditor.com/license.html.
 	<!--[if lt IE 9]>
 	<script src="assets/html5shiv.min.js"></script>
 	<![endif]-->
-	<link rel="icon" href="../theme/img/favicon.ico">
+	<link rel="icon" href="../template/theme/img/favicon.ico">
 </head>
 <body>
 	<header class="sdk-header">

--- a/samples/magicline.html
+++ b/samples/magicline.html
@@ -11,8 +11,8 @@ For licensing, see license.html or http://sdk.ckeditor.com/license.html.
 	<meta name="sdk-samples" content="Magic line">
 	<title>Magic Line</title>
 	<link href="http://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
-	<link href="../theme/css/sdk.css" rel="stylesheet">
-	<script src="../vendor/ckeditor/ckeditor.js"></script>
+	<link href="../template/theme/css/sdk.css" rel="stylesheet">
+	<script src="../../ckeditor-dev/ckeditor.js"></script>
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/contentloaded.js"></script>
 	<script src="assets/simplesample.js"></script>
@@ -20,7 +20,7 @@ For licensing, see license.html or http://sdk.ckeditor.com/license.html.
 	<!--[if lt IE 9]>
 	<script src="assets/html5shiv.min.js"></script>
 	<![endif]-->
-	<link rel="icon" href="../theme/img/favicon.ico">
+	<link rel="icon" href="../template/theme/img/favicon.ico">
 </head>
 <body>
 	<header class="sdk-header">

--- a/samples/mathjax.html
+++ b/samples/mathjax.html
@@ -11,8 +11,8 @@ For licensing, see license.html or http://sdk.ckeditor.com/license.html.
 	<meta name="sdk-samples" content="Creating mathematical formulas">
 	<title>Mathematical Formulas</title>
 	<link href="http://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
-	<link href="../theme/css/sdk.css" rel="stylesheet">
-	<script src="../vendor/ckeditor/ckeditor.js"></script>
+	<link href="../template/theme/css/sdk.css" rel="stylesheet">
+	<script src="../../ckeditor-dev/ckeditor.js"></script>
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/sample.js"></script>
 	<script src="assets/contentloaded.js"></script>
@@ -21,7 +21,7 @@ For licensing, see license.html or http://sdk.ckeditor.com/license.html.
 	<!--[if lt IE 9]>
 	<script src="assets/html5shiv.min.js"></script>
 	<![endif]-->
-	<link rel="icon" href="../theme/img/favicon.ico">
+	<link rel="icon" href="../template/theme/img/favicon.ico">
 </head>
 <body>
 	<header class="sdk-header">

--- a/samples/mediaembed.html
+++ b/samples/mediaembed.html
@@ -11,8 +11,8 @@ For licensing, see license.html or http://sdk.ckeditor.com/license.html.
 	<meta name="sdk-samples" content="Using Media Embed with Auto Embed">
 	<title>Embedding Media Resources</title>
 	<link href="http://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
-	<link href="../theme/css/sdk.css" rel="stylesheet">
-	<script src="../vendor/ckeditor/ckeditor.js"></script>
+	<link href="../template/theme/css/sdk.css" rel="stylesheet">
+	<script src="../../ckeditor-dev/ckeditor.js"></script>
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/sample.js"></script>
 	<script src="assets/contentloaded.js"></script>
@@ -21,7 +21,7 @@ For licensing, see license.html or http://sdk.ckeditor.com/license.html.
 	<!--[if lt IE 9]>
 	<script src="assets/html5shiv.min.js"></script>
 	<![endif]-->
-	<link rel="icon" href="../theme/img/favicon.ico">
+	<link rel="icon" href="../template/theme/img/favicon.ico">
 	<style>
 		.exampleResources input {
 			margin-bottom: 1px;

--- a/samples/placeholder.html
+++ b/samples/placeholder.html
@@ -11,8 +11,8 @@ For licensing, see license.html or http://sdk.ckeditor.com/license.html.
 	<meta name="sdk-samples" content="Using placeholders">
 	<title>Placeholders</title>
 	<link href="http://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
-	<link href="../theme/css/sdk.css" rel="stylesheet">
-	<script src="../vendor/ckeditor/ckeditor.js"></script>
+	<link href="../template/theme/css/sdk.css" rel="stylesheet">
+	<script src="../../ckeditor-dev/ckeditor.js"></script>
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/sample.js"></script>
 	<script src="assets/contentloaded.js"></script>
@@ -21,7 +21,7 @@ For licensing, see license.html or http://sdk.ckeditor.com/license.html.
 	<!--[if lt IE 9]>
 	<script src="assets/html5shiv.min.js"></script>
 	<![endif]-->
-	<link rel="icon" href="../theme/img/favicon.ico">
+	<link rel="icon" href="../template/theme/img/favicon.ico">
 </head>
 <body>
 	<header class="sdk-header">

--- a/samples/readonly.html
+++ b/samples/readonly.html
@@ -11,12 +11,12 @@ For licensing, see license.html or http://sdk.ckeditor.com/license.html.
 	<meta name="sdk-samples" content="Read-only mode">
 	<title>Read-Only Mode</title>
 	<link href="http://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
-	<link href="../theme/css/sdk.css" rel="stylesheet">
+	<link href="../template/theme/css/sdk.css" rel="stylesheet">
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/contentloaded.js"></script>
 	<script src="assets/simplesample.js"></script>
 	<script src="assets/beautify-html.js"></script>
-	<script src="../vendor/ckeditor/ckeditor.js"></script>
+	<script src="../../ckeditor-dev/ckeditor.js"></script>
 	<script data-sample="1">
 		var editor;
 
@@ -44,7 +44,7 @@ For licensing, see license.html or http://sdk.ckeditor.com/license.html.
 	<!--[if lt IE 9]>
 	<script src="assets/html5shiv.min.js"></script>
 	<![endif]-->
-	<link rel="icon" href="../theme/img/favicon.ico">
+	<link rel="icon" href="../template/theme/img/favicon.ico">
 </head>
 <body>
 	<header class="sdk-header">

--- a/samples/removeformat.html
+++ b/samples/removeformat.html
@@ -11,8 +11,8 @@ For licensing, see license.html or http://sdk.ckeditor.com/license.html.
 	<meta name="sdk-samples" content="Removing text formatting">
 	<title>Removing Text Formatting</title>
 	<link href="http://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
-	<link href="../theme/css/sdk.css" rel="stylesheet">
-	<script src="../vendor/ckeditor/ckeditor.js"></script>
+	<link href="../template/theme/css/sdk.css" rel="stylesheet">
+	<script src="../../ckeditor-dev/ckeditor.js"></script>
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/sample.js"></script>
 	<script src="assets/contentloaded.js"></script>
@@ -21,7 +21,7 @@ For licensing, see license.html or http://sdk.ckeditor.com/license.html.
 	<!--[if lt IE 9]>
 	<script src="assets/html5shiv.min.js"></script>
 	<![endif]-->
-	<link rel="icon" href="../theme/img/favicon.ico">
+	<link rel="icon" href="../template/theme/img/favicon.ico">
 </head>
 <body>
 	<header class="sdk-header">

--- a/samples/resize.html
+++ b/samples/resize.html
@@ -11,8 +11,8 @@ For licensing, see license.html or http://sdk.ckeditor.com/license.html.
 	<meta name="sdk-samples" content="Editor resizing customization">
 	<title>Resizing Customization</title>
 	<link href="http://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
-	<link href="../theme/css/sdk.css" rel="stylesheet">
-	<script src="../vendor/ckeditor/ckeditor.js"></script>
+	<link href="../template/theme/css/sdk.css" rel="stylesheet">
+	<script src="../../ckeditor-dev/ckeditor.js"></script>
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/contentloaded.js"></script>
 	<script src="assets/simplesample.js"></script>
@@ -20,7 +20,7 @@ For licensing, see license.html or http://sdk.ckeditor.com/license.html.
 	<!--[if lt IE 9]>
 	<script src="assets/html5shiv.min.js"></script>
 	<![endif]-->
-	<link rel="icon" href="../theme/img/favicon.ico">
+	<link rel="icon" href="../template/theme/img/favicon.ico">
 </head>
 <body>
 	<header class="sdk-header">

--- a/samples/saveajax.html
+++ b/samples/saveajax.html
@@ -11,8 +11,8 @@ For licensing, see license.html or http://sdk.ckeditor.com/license.html.
 	<meta name="sdk-samples" content="Creating and destroying CKEditor on the fly|The &lt;code&gt;change&lt;/code&gt; event">
 	<title>Saving in Ajax Applications</title>
 	<link href="http://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
-	<link href="../theme/css/sdk.css" rel="stylesheet">
-	<script src="../vendor/ckeditor/ckeditor.js"></script>
+	<link href="../template/theme/css/sdk.css" rel="stylesheet">
+	<script src="../../ckeditor-dev/ckeditor.js"></script>
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/sample.js"></script>
 	<script src="assets/contentloaded.js"></script>
@@ -59,7 +59,7 @@ For licensing, see license.html or http://sdk.ckeditor.com/license.html.
 			editor1 = null;
 		}
 	</script>
-	<link rel="icon" href="../theme/img/favicon.ico">
+	<link rel="icon" href="../template/theme/img/favicon.ico">
 </head>
 <body>
 	<header class="sdk-header">

--- a/samples/savetextarea.html
+++ b/samples/savetextarea.html
@@ -11,14 +11,14 @@ For licensing, see license.html or http://sdk.ckeditor.com/license.html.
 	<meta name="sdk-samples" content="Classic editor replacing a textarea|Inline editor replacing a textarea">
 	<title>Saving Textarea Data</title>
 	<link href="http://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
-	<link href="../theme/css/sdk.css" rel="stylesheet">
-	<script src="../vendor/ckeditor/ckeditor.js"></script>
+	<link href="../template/theme/css/sdk.css" rel="stylesheet">
+	<script src="../../ckeditor-dev/ckeditor.js"></script>
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/contentloaded.js"></script>
 	<script src="assets/simplesample.js"></script>
 	<script src="assets/beautify-html.js"></script>
 	<script type="template" data-sample="2">
-		&lt;link href="../theme/css/sdk-inline.css" rel="stylesheet" /&gt;
+		&lt;link href="../template/theme/css/sdk-inline.css" rel="stylesheet" /&gt;
 	</script>
 	<!--[if lt IE 9]>
 	<script src="assets/html5shiv.min.js"></script>
@@ -30,7 +30,7 @@ For licensing, see license.html or http://sdk.ckeditor.com/license.html.
 			min-height: 300px;
 		}
 	</style>
-	<link rel="icon" href="../theme/img/favicon.ico">
+	<link rel="icon" href="../template/theme/img/favicon.ico">
 </head>
 <body>
 	<header class="sdk-header">

--- a/samples/sharedspace.html
+++ b/samples/sharedspace.html
@@ -11,14 +11,14 @@ For licensing, see license.html or http://sdk.ckeditor.com/license.html.
 	<meta name="sdk-samples" content="Classic editors sharing toolbar and bottom bar|Inline editor with shared toolbar and bottom bar">
 	<title>Shared User Interface</title>
 	<link href="http://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
-	<link href="../theme/css/sdk.css" rel="stylesheet">
-	<script src="../vendor/ckeditor/ckeditor.js"></script>
+	<link href="../template/theme/css/sdk.css" rel="stylesheet">
+	<script src="../../ckeditor-dev/ckeditor.js"></script>
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/contentloaded.js"></script>
 	<script src="assets/simplesample.js"></script>
 	<script src="assets/beautify-html.js"></script>
 	<script type="template" data-sample="2">
-		&lt;link href="../theme/css/sdk-inline.css" rel="stylesheet"&gt;
+		&lt;link href="../template/theme/css/sdk-inline.css" rel="stylesheet"&gt;
 	</script>
 	<!--[if lt IE 9]>
 	<script src="assets/html5shiv.min.js"></script>
@@ -36,7 +36,7 @@ For licensing, see license.html or http://sdk.ckeditor.com/license.html.
 			overflow-y: auto;
 		}
 	</style>
-	<link rel="icon" href="../theme/img/favicon.ico">
+	<link rel="icon" href="../template/theme/img/favicon.ico">
 </head>
 <body>
 	<header class="sdk-header">

--- a/samples/simplebox.html
+++ b/samples/simplebox.html
@@ -11,8 +11,8 @@ For licensing, see license.html or http://sdk.ckeditor.com/license.html.
 	<meta name="sdk-samples" content="Simple box widget">
 	<title>Custom Widget</title>
 	<link href="http://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
-	<link href="../theme/css/sdk.css" rel="stylesheet">
-	<script src="../vendor/ckeditor/ckeditor.js"></script>
+	<link href="../template/theme/css/sdk.css" rel="stylesheet">
+	<script src="../../ckeditor-dev/ckeditor.js"></script>
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/sample.js"></script>
 	<script src="assets/contentloaded.js"></script>
@@ -21,7 +21,7 @@ For licensing, see license.html or http://sdk.ckeditor.com/license.html.
 	<!--[if lt IE 9]>
 	<script src="assets/html5shiv.min.js"></script>
 	<![endif]-->
-	<link rel="icon" href="../theme/img/favicon.ico">
+	<link rel="icon" href="../template/theme/img/favicon.ico">
 </head>
 <body>
 	<header class="sdk-header">
@@ -105,7 +105,7 @@ For licensing, see license.html or http://sdk.ckeditor.com/license.html.
 					// In the usual case they can be added to the main stylesheet.
 					contentsCss: [
 						'assets/plugins/simplebox/styles/contents.css',
-						'../vendor/ckeditor/contents.css'
+						'../../ckeditor-dev/contents.css'
 					],
 
 					// Set height to make more content visible.

--- a/samples/size.html
+++ b/samples/size.html
@@ -11,8 +11,8 @@ For licensing, see license.html or http://sdk.ckeditor.com/license.html.
 	<meta name="sdk-samples" content="Setting editor size">
 	<title>Editor Size</title>
 	<link href="http://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
-	<link href="../theme/css/sdk.css" rel="stylesheet">
-	<script src="../vendor/ckeditor/ckeditor.js"></script>
+	<link href="../template/theme/css/sdk.css" rel="stylesheet">
+	<script src="../../ckeditor-dev/ckeditor.js"></script>
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/contentloaded.js"></script>
 	<script src="assets/simplesample.js"></script>
@@ -20,7 +20,7 @@ For licensing, see license.html or http://sdk.ckeditor.com/license.html.
 	<!--[if lt IE 9]>
 	<script src="assets/html5shiv.min.js"></script>
 	<![endif]-->
-	<link rel="icon" href="../theme/img/favicon.ico">
+	<link rel="icon" href="../template/theme/img/favicon.ico">
 </head>
 <body>
 	<header class="sdk-header">

--- a/samples/sourcearea.html
+++ b/samples/sourcearea.html
@@ -11,20 +11,20 @@ For licensing, see license.html or http://sdk.ckeditor.com/license.html.
 	<meta name="sdk-samples" content="Classic editor with default source editing area|Inline editor with source dialog|Classic editor with source dialog">
 	<title>Source Code Editing</title>
 	<link href="http://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
-	<link href="../theme/css/sdk.css" rel="stylesheet">
-	<script src="../vendor/ckeditor/ckeditor.js"></script>
+	<link href="../template/theme/css/sdk.css" rel="stylesheet">
+	<script src="../../ckeditor-dev/ckeditor.js"></script>
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/sample.js"></script>
 	<script src="assets/contentloaded.js"></script>
 	<script src="assets/simplesample.js"></script>
 	<script src="assets/beautify-html.js"></script>
 	<script type="template" data-sample="2">
-		&lt;link href="../theme/css/sdk-inline.css" rel="stylesheet" /&gt;
+		&lt;link href="../template/theme/css/sdk-inline.css" rel="stylesheet" /&gt;
 	</script>
 	<!--[if lt IE 9]>
 	<script src="assets/html5shiv.min.js"></script>
 	<![endif]-->
-	<link rel="icon" href="../theme/img/favicon.ico">
+	<link rel="icon" href="../template/theme/img/favicon.ico">
 </head>
 <body>
 	<header class="sdk-header">

--- a/samples/spellchecker.html
+++ b/samples/spellchecker.html
@@ -11,8 +11,8 @@ For licensing, see license.html or http://sdk.ckeditor.com/license.html.
 	<meta name="sdk-samples" content="Spell Check As You Type (SCAYT)|Spell checker in a dialog window|Native browser spell checker">
 	<title>Spell Checking</title>
 	<link href="http://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
-	<link href="../theme/css/sdk.css" rel="stylesheet">
-	<script src="../vendor/ckeditor/ckeditor.js"></script>
+	<link href="../template/theme/css/sdk.css" rel="stylesheet">
+	<script src="../../ckeditor-dev/ckeditor.js"></script>
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/sample.js"></script>
 	<script src="assets/contentloaded.js"></script>
@@ -21,7 +21,7 @@ For licensing, see license.html or http://sdk.ckeditor.com/license.html.
 	<!--[if lt IE 9]>
 	<script src="assets/html5shiv.min.js"></script>
 	<![endif]-->
-	<link rel="icon" href="../theme/img/favicon.ico">
+	<link rel="icon" href="../template/theme/img/favicon.ico">
 </head>
 <body>
 	<header class="sdk-header">

--- a/samples/styles.html
+++ b/samples/styles.html
@@ -11,8 +11,8 @@ For licensing, see license.html or http://sdk.ckeditor.com/license.html.
 	<meta name="sdk-samples" content="Default Styles Combo plugin implementation|Stylesheet Parser plugin">
 	<title>Styles and Stylesheet Parser</title>
 	<link href="http://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
-	<link href="../theme/css/sdk.css" rel="stylesheet">
-	<script src="../vendor/ckeditor/ckeditor.js"></script>
+	<link href="../template/theme/css/sdk.css" rel="stylesheet">
+	<script src="../../ckeditor-dev/ckeditor.js"></script>
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/sample.js"></script>
 	<script src="assets/contentloaded.js"></script>
@@ -21,7 +21,7 @@ For licensing, see license.html or http://sdk.ckeditor.com/license.html.
 	<!--[if lt IE 9]>
 	<script src="assets/html5shiv.min.js"></script>
 	<![endif]-->
-	<link rel="icon" href="../theme/img/favicon.ico">
+	<link rel="icon" href="../template/theme/img/favicon.ico">
 </head>
 <body>
 	<header class="sdk-header">

--- a/samples/tabindex.html
+++ b/samples/tabindex.html
@@ -10,15 +10,15 @@ For licensing, see license.html or http://sdk.ckeditor.com/license.html.
 	<meta name="keywords" content="ckeditor, editor, wysiwyg, tab, navigation, accessibility, keyboard, keystrokes, configure, configuration, setup, settings, options, customization, customize, customise, customisation, config, modification, modify, change">
 	<title>&quot;Tab&quot; Key Navigation</title>
 	<link href="http://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
-	<link href="../theme/css/sdk.css" rel="stylesheet">
-	<script src="../vendor/ckeditor/ckeditor.js"></script>
+	<link href="../template/theme/css/sdk.css" rel="stylesheet">
+	<script src="../../ckeditor-dev/ckeditor.js"></script>
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/contentloaded.js"></script>
 	<script src="assets/simplesample.js"></script>
 	<!--[if lt IE 9]>
 	<script src="assets/html5shiv.min.js"></script>
 	<![endif]-->
-	<link rel="icon" href="../theme/img/favicon.ico">
+	<link rel="icon" href="../template/theme/img/favicon.ico">
 </head>
 <body>
 	<header class="sdk-header">

--- a/samples/table.html
+++ b/samples/table.html
@@ -11,8 +11,8 @@ For licensing, see license.html or http://sdk.ckeditor.com/license.html.
 	<meta name="sdk-samples" content="Table support with column resizing">
 	<title>Tables with Column Resizing</title>
 	<link href="http://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
-	<link href="../theme/css/sdk.css" rel="stylesheet">
-	<script src="../vendor/ckeditor/ckeditor.js"></script>
+	<link href="../template/theme/css/sdk.css" rel="stylesheet">
+	<script src="../../ckeditor-dev/ckeditor.js"></script>
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/contentloaded.js"></script>
 	<script src="assets/simplesample.js"></script>
@@ -20,7 +20,7 @@ For licensing, see license.html or http://sdk.ckeditor.com/license.html.
 	<!--[if lt IE 9]>
 	<script src="assets/html5shiv.min.js"></script>
 	<![endif]-->
-	<link rel="icon" href="../theme/img/favicon.ico">
+	<link rel="icon" href="../template/theme/img/favicon.ico">
 </head>
 <body>
 	<header class="sdk-header">

--- a/samples/timestamp.html
+++ b/samples/timestamp.html
@@ -11,8 +11,8 @@ For licensing, see license.html or http://sdk.ckeditor.com/license.html.
 	<meta name="sdk-samples" content="Timestamp plugin">
 	<title>Timestamp Plugin</title>
 	<link href="http://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
-	<link href="../theme/css/sdk.css" rel="stylesheet">
-	<script src="../vendor/ckeditor/ckeditor.js"></script>
+	<link href="../template/theme/css/sdk.css" rel="stylesheet">
+	<script src="../../ckeditor-dev/ckeditor.js"></script>
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/sample.js"></script>
 	<script src="assets/contentloaded.js"></script>
@@ -21,7 +21,7 @@ For licensing, see license.html or http://sdk.ckeditor.com/license.html.
 	<!--[if lt IE 9]>
 	<script src="assets/html5shiv.min.js"></script>
 	<![endif]-->
-	<link rel="icon" href="../theme/img/favicon.ico">
+	<link rel="icon" href="../template/theme/img/favicon.ico">
 </head>
 <body>
 	<header class="sdk-header">

--- a/samples/toolbar.html
+++ b/samples/toolbar.html
@@ -11,8 +11,8 @@ For licensing, see license.html or http://sdk.ckeditor.com/license.html.
 	<meta name="sdk-samples" content="Custom toolbar">
 	<title>Custom Toolbar</title>
 	<link href="http://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
-	<link href="../theme/css/sdk.css" rel="stylesheet">
-	<script src="../vendor/ckeditor/ckeditor.js"></script>
+	<link href="../template/theme/css/sdk.css" rel="stylesheet">
+	<script src="../../ckeditor-dev/ckeditor.js"></script>
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/contentloaded.js"></script>
 	<script src="assets/simplesample.js"></script>
@@ -20,7 +20,7 @@ For licensing, see license.html or http://sdk.ckeditor.com/license.html.
 	<!--[if lt IE 9]>
 	<script src="assets/html5shiv.min.js"></script>
 	<![endif]-->
-	<link rel="icon" href="../theme/img/favicon.ico">
+	<link rel="icon" href="../template/theme/img/favicon.ico">
 </head>
 <body>
 	<header class="sdk-header">

--- a/samples/toolbarlocation.html
+++ b/samples/toolbarlocation.html
@@ -11,8 +11,8 @@ For licensing, see license.html or http://sdk.ckeditor.com/license.html.
 	<meta name="sdk-samples" content="Toolbar location adjustment">
 	<title>Toolbar Location</title>
 	<link href="http://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
-	<link href="../theme/css/sdk.css" rel="stylesheet">
-	<script src="../vendor/ckeditor/ckeditor.js"></script>
+	<link href="../template/theme/css/sdk.css" rel="stylesheet">
+	<script src="../../ckeditor-dev/ckeditor.js"></script>
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/contentloaded.js"></script>
 	<script src="assets/simplesample.js"></script>
@@ -20,7 +20,7 @@ For licensing, see license.html or http://sdk.ckeditor.com/license.html.
 	<!--[if lt IE 9]>
 	<script src="assets/html5shiv.min.js"></script>
 	<![endif]-->
-	<link rel="icon" href="../theme/img/favicon.ico">
+	<link rel="icon" href="../template/theme/img/favicon.ico">
 </head>
 <body>
 	<header class="sdk-header">

--- a/samples/uicolor.html
+++ b/samples/uicolor.html
@@ -11,8 +11,8 @@ For licensing, see license.html or http://sdk.ckeditor.com/license.html.
 	<meta name="sdk-samples" content="Setting editor UI color">
 	<title>UI Color</title>
 	<link href="http://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
-	<link href="../theme/css/sdk.css" rel="stylesheet">
-	<script src="../vendor/ckeditor/ckeditor.js"></script>
+	<link href="../template/theme/css/sdk.css" rel="stylesheet">
+	<script src="../../ckeditor-dev/ckeditor.js"></script>
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/contentloaded.js"></script>
 	<script src="assets/simplesample.js"></script>
@@ -20,7 +20,7 @@ For licensing, see license.html or http://sdk.ckeditor.com/license.html.
 	<!--[if lt IE 9]>
 	<script src="assets/html5shiv.min.js"></script>
 	<![endif]-->
-	<link rel="icon" href="../theme/img/favicon.ico">
+	<link rel="icon" href="../template/theme/img/favicon.ico">
 </head>
 <body>
 	<header class="sdk-header">

--- a/samples/uicolorpicker.html
+++ b/samples/uicolorpicker.html
@@ -11,8 +11,8 @@ For licensing, see license.html or http://sdk.ckeditor.com/license.html.
 	<meta name="sdk-samples" content="UI color picker">
 	<title>UI Color Picker</title>
 	<link href="http://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
-	<link href="../theme/css/sdk.css" rel="stylesheet">
-	<script src="../vendor/ckeditor/ckeditor.js"></script>
+	<link href="../template/theme/css/sdk.css" rel="stylesheet">
+	<script src="../../ckeditor-dev/ckeditor.js"></script>
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/sample.js"></script>
 	<script src="assets/contentloaded.js"></script>
@@ -21,7 +21,7 @@ For licensing, see license.html or http://sdk.ckeditor.com/license.html.
 	<!--[if lt IE 9]>
 	<script src="assets/html5shiv.min.js"></script>
 	<![endif]-->
-	<link rel="icon" href="../theme/img/favicon.ico">
+	<link rel="icon" href="../template/theme/img/favicon.ico">
 </head>
 <body>
 	<header class="sdk-header">

--- a/samples/uilanguages.html
+++ b/samples/uilanguages.html
@@ -11,8 +11,8 @@ For licensing, see license.html or http://sdk.ckeditor.com/license.html.
 	<meta name="sdk-samples" content="Setting editor UI language">
 	<title>UI Language</title>
 	<link href="http://fonts.googleapis.com/css?family=Maven+Pro:700,500,400" rel="stylesheet">
-	<link href="../theme/css/sdk.css" rel="stylesheet">
-	<script src="../vendor/ckeditor/ckeditor.js"></script>
+	<link href="../template/theme/css/sdk.css" rel="stylesheet">
+	<script src="../../ckeditor-dev/ckeditor.js"></script>
 	<script src="assets/picoModal-2.0.1.min.js"></script>
 	<script src="assets/uilanguages/languages.js"></script>
 	<script src="assets/contentloaded.js"></script>
@@ -21,7 +21,7 @@ For licensing, see license.html or http://sdk.ckeditor.com/license.html.
 	<!--[if lt IE 9]>
 	<script src="assets/html5shiv.min.js"></script>
 	<![endif]-->
-	<link rel="icon" href="../theme/img/favicon.ico">
+	<link rel="icon" href="../template/theme/img/favicon.ico">
 </head>
 <body>
 	<header class="sdk-header">


### PR DESCRIPTION
#159.

After some wrestling with the system I established, that given how many operations are done on the sample files during building it's best not to replicate this behavior in the dev environment so I settled on only modifying the paths of the CSS file and CKEditor script.

At this point the main difference between the dev and built samples is a lack of navigation in the former.