### PR TITLE
Get rid of googlecode.css in savetextarea.php

### DIFF
--- a/dev/builder/app.js
+++ b/dev/builder/app.js
@@ -231,12 +231,18 @@ function copyCKEditor() {
     return call( ncp, CKEDITOR_PATH, path.join( RELEASE_PATH, 'vendor', 'ckeditor' ) );
 }
 
-function copyGuides( urls ) {
+function copyGuides() {
     console.log( 'Copying guides' );
+    var urls = [];
 
-    return when.promise( function ( resolve, reject ) {
-        call( ncp, '../../docs/guides', RELEASE_PATH + '/../guides' ).done( function() {
-            resolve();
+    return when.promise( function( resolve, reject ) {
+        call( ncp, '../../docs/guides', RELEASE_PATH + '/../guides', {
+            transform: function( read, write ) {
+                urls.push( read.path.match( /guides\/(.*)/ )[ 1 ] );
+                read.pipe( write );
+            }
+        } ).done( function() {
+            resolve( urls );
         }, reject);
     });
 }
@@ -653,16 +659,20 @@ function saveFiles( data ) {
  */
 function fixGuidesLinks( urls ) {
     console.log( 'Fixing guides links' );
-    var filesReadPromises = _.map( urls, function( url ) {
-        url = path.resolve( '../guides/' + url );
-        var promise = whenFs.readFile( url, 'utf8' );
+    var filesReadPromises = urls
+        .filter( function( url ) {
+            return url.match( /\.md$/ );
+        } )
+        .map( function( url ) {
+            url = path.resolve( '../guides/' + url );
+            var promise = whenFs.readFile( url, 'utf8' );
 
-        return [ url, promise ];
-    } );
+            return [ url, promise ];
+        } );
     filesReadPromises = _.object( filesReadPromises );
 
     return whenKeys.map( filesReadPromises, function mapper( content ) {
-        return content.replace( /(\[.*?\])\((?:http:\/\/sdk\.ckeditor\.com([^)]*?))\)/, '$1(..$2)' );
+        return content.replace( /(\[.*?\])\((?:https?:\/\/sdk\.ckeditor\.com([^)]*?))\)/g, '$1(..$2)' );
     } );
 }
 

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -22,6 +22,9 @@ module.exports = function( grunt ) {
 
 			'builder-setup': {
 				command: [
+					'cd docs',
+					'npm install',
+					'cd ..',
 					'cd ' + BUILDER_DIR,
 					'npm install'
 				].join( '&&' )

--- a/samples/savetextarea.php
+++ b/samples/savetextarea.php
@@ -10,7 +10,6 @@ For licensing, see license.html or http://sdk.ckeditor.com/license.html.
 	<meta charset="utf-8">
 	<title>Saving Data in CKEditor Replacing a Textarea</title>
 	<link rel="stylesheet" href="../theme/css/sdk.css">
-	<link rel="stylesheet" href="highlight/styles/googlecode.css">
 	<style>
 	pre code {
 		white-space: pre-wrap;
@@ -19,6 +18,8 @@ For licensing, see license.html or http://sdk.ckeditor.com/license.html.
 	}
 	</style>
 	<link rel="icon" href="../theme/img/favicon.ico">
+	<link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.7/styles/github.min.css">
+	<script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.7/highlight.min.js"></script>
 </head>
 <body>
 	<section class="sdk-container">
@@ -68,6 +69,8 @@ For licensing, see license.html or http://sdk.ckeditor.com/license.html.
 	<footer class="sdk-footer">
 
 	</footer>
-
+	<script>
+		hljs.highlightBlock( document.querySelector( '.html' ) );
+	</script>
 </body>
 </html>


### PR DESCRIPTION
The link that resulted in a 404 in #162 was probably put there to highlight the code.

I found a replacement in the form of https://highlightjs.org/ and since savetextarea.php is served only online I used a CDN for the dependencies.