### PR TITLE
Sdk fix windows

### DIFF
--- a/dev/builder/app.js
+++ b/dev/builder/app.js
@@ -645,6 +645,10 @@ function curryExec( command, args, silent ) {
                     reject( code );
                 }
             } );
+
+            cmd.on( 'error', function( err ) {
+                console.log( 'Error "' + err + '" while executing command: "' + command + ' ' + args.join( ' ' ) + '"' );
+            } );
         } );
     }
 }

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -13,6 +13,7 @@ module.exports = function( grunt ) {
 	grunt.loadNpmTasks( 'grunt-shell' );
 	grunt.loadNpmTasks( 'grunt-contrib-compass' );
 	grunt.loadNpmTasks( 'grunt-text-replace' );
+	grunt.loadNpmTasks( 'grunt-mkdir' );
 
 	grunt.registerTask( 'default', 'build' );
 
@@ -36,7 +37,6 @@ module.exports = function( grunt ) {
 
 			'sdk-build': {
 				command: [
-					'mkdir -p build',
 					'cd ' + BUILDER_DIR,
 					[
 						'node ./app.js',
@@ -71,6 +71,14 @@ module.exports = function( grunt ) {
 					'git commit -a -m "Updated CKEditor presets and docs submodule HEADs."',
 					'git submodule update --init --recursive'
 				].join( '&&' )
+			}
+		},
+
+		mkdir: {
+			build: {
+				options: {
+					create: [ 'build' ]
+				}
 			}
 		},
 
@@ -119,6 +127,7 @@ module.exports = function( grunt ) {
 
 	grunt.registerTask( 'build', [
 		'compass:sdk-build-css',
+		'mkdir:build',
 		'shell:sdk-build'
 	] );
 

--- a/package.json
+++ b/package.json
@@ -4,8 +4,9 @@
 	"description": "A set of software development tools for CKEditor along with samples.",
 	"dependencies": {
 		"grunt": "~0.4.5",
-		"grunt-shell": "~0.5.0",
 		"grunt-contrib-compass": "~1.0.1",
+		"grunt-mkdir": "^0.1.2",
+		"grunt-shell": "~0.5.0",
 		"grunt-text-replace": "^0.4.0"
 	},
 	"scripts": {


### PR DESCRIPTION
Rather than using commands that might not work on all systems we should use tasks that solves it from all platform.

The problem in #167 shown me that it's kinda hard to get to the source of the problem without getting deeper into the code of sdk code. I wanted to show more detailed message, but it seems that child_process.spawn exceptions does not contain detailed information printed by (failed) command.