### PR TITLE
Enabled dev docs link for the Balloon Toolbar

### DIFF
--- a/samples/balloontoolbar.html
+++ b/samples/balloontoolbar.html
@@ -30,7 +30,7 @@ For licensing, see license.html or https://sdk.ckeditor.com/license.html.
 		<nav class="sdk-sidebar">
 		</nav>
 		<section class="sdk-contents">
-			<h1>Balloon Toolbar <!-- <a class="documentation" href="https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_balloon_toolbar">Documentation</a> --></h1>
+			<h1>Balloon Toolbar <a class="documentation" href="https://docs.ckeditor.com/ckeditor4/docs/#!/guide/dev_balloontoolbar">Documentation</a></h1>
 
 			<p>
 				The optional <a href="https://ckeditor.com/cke4/addon/balloontoolbar">Balloon Toolbar</a> plugin, introduced in CKEditor 4.8, allows for adding context-aware toolbars in the editor.


### PR DESCRIPTION
So far it has been commented out. Since docs arrived we can enable. Note that the link is slightly different from what I have expected.