### PR TITLE
Update CKEditor output path

### DIFF
--- a/dev/builder/app.js
+++ b/dev/builder/app.js
@@ -325,11 +325,11 @@ function prepareSamplesFilesSync() {
         sample.activateSamplesButton();
         if ( opts.version === 'offline' ) {
             sample.preventSearchEngineRobots();
-            sample.fixExternalPaths();
+            sample.fixExternalPaths( CKEDITOR_VERSION );
             sample.fixLinks();
             sample.fixFonts();
         } else {
-            sample.fixExternalPaths();
+            sample.fixExternalPaths( CKEDITOR_VERSION );
             sample.fixCKEDITORVendorLinks( CKEDITOR_VERSION );
         }
 

--- a/dev/builder/app.js
+++ b/dev/builder/app.js
@@ -245,8 +245,9 @@ function copyVendor() {
 
 function copyCKEditor() {
     console.log( 'Copying CKEditor files' );
+    fs.mkdirSync( path.join( RELEASE_PATH, 'vendor', 'ckeditor' ) );
 
-    return call( ncp, CKEDITOR_PATH, path.join( RELEASE_PATH, 'vendor', 'ckeditor' ) );
+    return call( ncp, CKEDITOR_PATH, path.join( RELEASE_PATH, 'vendor', 'ckeditor', CKEDITOR_VERSION ) );
 }
 
 function copyGuides() {

--- a/dev/builder/lib/Sample.js
+++ b/dev/builder/lib/Sample.js
@@ -116,13 +116,13 @@ Sample.prototype = {
         } );
     },
 
-    fixExternalPaths: function() {
+    fixExternalPaths: function( version ) {
         // This is bad, but there's no real alternative to this given,
         // that the path that needs to be modified may appear within a script.
         var html = this.$( 'html' ).html();
         if ( html ) {
             this.$( 'html' ).html( html
-                .replace( /\.\.\/\.\.\/ckeditor\-dev/g, '../vendor/ckeditor' )
+                .replace( /\.\.\/\.\.\/ckeditor\-dev/g, '../vendor/ckeditor/' + version )
                 .replace( /\.\.\/template\/theme/g, '../theme' ) );
         }
     },
@@ -156,8 +156,8 @@ Sample.prototype = {
                     return $1 + $2.replace( '../..', 'https://sdk.ckeditor.com' ) + $3;
                 }
 
-                if ( $2.indexOf( '../vendor/ckeditor/' ) != -1 ) {
-                    return $1 + $2.replace( '../vendor/ckeditor/', 'https:' + cdnEditorLink ) + $3;
+                if ( $2.indexOf( '../vendor/ckeditor/' + version + '/' ) != -1 ) {
+                    return $1 + $2.replace( '../vendor/ckeditor/' + version + '/', 'https:' + cdnEditorLink ) + $3;
                 }
 
                 return $1 + $2 + $3;


### PR DESCRIPTION
This PR introduces versioned directories for CKEditor, e.g. `vendor/ckeditor/4.9.0`.