### PR TITLE
Fixed content typo in Copy Formatting sample

### DIFF
--- a/samples/copyformatting.html
+++ b/samples/copyformatting.html
@@ -60,7 +60,7 @@ For licensing, see license.html or https://sdk.ckeditor.com/license.html.
 			<textarea cols="80" id="editor1" name="editor1" rows="10" data-sample="1" data-sample-short>
 				&lt;h1&gt;Apollo 11&lt;/h1&gt;
 
-				&lt;p&gt;&lt;strong&gt;Apollo 11&lt;sup&gt;1&lt;/sup&gt;&lt;/strong&gt;&amp;nbsp;was the spaceflight that landed the first
+				&lt;p&gt;&lt;strong&gt;Apollo 11&lt;/strong&gt; was the spaceflight that landed the first
 				humans, Americans &lt;em&gt;&lt;strong&gt;Neil Armstrong&lt;/strong&gt;&lt;/em&gt; and &lt;em&gt;&lt;strong&gt;Buzz
 				Aldrin&lt;/strong&gt;&lt;/em&gt;, on the Moon on &lt;u&gt;July 20, 1969, at 20:18 UTC&lt;/u&gt;. Armstrong became the first
 				to step onto the lunar surface 6 hours later on &lt;u&gt;July 21 at 02:56 UTC&lt;/u&gt;.&lt;/p&gt;


### PR DESCRIPTION
There's a typo in that sample:

> Apollo 111 was the spaceflight (…)

In addition to that there's a unnecessary `nbsp` entity.